### PR TITLE
Updated date

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
             <div class="col-xxl-6 col-xl-6 col-lg-6 col-md-10 col-sm-12 my-auto">
               <div class="container p-5 mob-text">
                 <h3 class="fw-bold">THERE'S NEVER BEEN A BETTER TIME TO BUY!</h3>
-                <p>*Offer is available for business borrowers only. This 1.5% p.a. ﬁnance rate offer is only available with a minimum 10% deposit, 36 months monthly repayments and a minimum ﬁnanced amount of $4,000. Terms, conditions, fees, charges and credit criteria apply. Different term and different deposit may result in a different rate. Credit provided by Kubota Australia Pty Ltd ABN 72005300621. This ﬁnance offer is available until 30/06/2024 and applies to new Kubota U & KX Series excavators.</p>                
+                <p>*Offer is available for business borrowers only. This 1.5% p.a. ﬁnance rate offer is only available with a minimum 10% deposit, 36 months monthly repayments and a minimum ﬁnanced amount of $4,000. Terms, conditions, fees, charges and credit criteria apply. Different term and different deposit may result in a different rate. Credit provided by Kubota Australia Pty Ltd ABN 72005300621. This ﬁnance offer is available until 31/10/2024 and applies to new Kubota U & KX Series excavators.</p>                
               </div>
             </div>
           </div>


### PR DESCRIPTION
now - This ﬁnance offer is available until 31/10/2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the expiration date for the finance offer on Kubota U & KX Series excavators from June 30, 2024, to October 31, 2024, in the promotional content on the webpage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->